### PR TITLE
Issues/468 filter getproperty for all processors

### DIFF
--- a/src/Microsoft.Health.Fhir.Liquid.Converter/Models/CodeMapping.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/Models/CodeMapping.cs
@@ -22,15 +22,14 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.Models
         /// Appends mappings from another CodeMapping instance.
         /// Throws InvalidOperationException if any key path already exists with a different value.
         /// </summary>
-        /// <param name="other">The other CodeMapping to append.</param>
-        public void Append(CodeMapping other)
+        /// <param name="additionalMapping">The CodeMapping to append.</param>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="mappingToAppend"/> is null.</exception>
+        /// <exception cref="InvalidOperationException">Thrown if any key path already exists with a different value.</exception>
+        public void Append(CodeMapping additionalMapping)
         {
-            if (other == null)
-            {
-                throw new ArgumentNullException(nameof(other));
-            }
+            ArgumentNullException.ThrowIfNull(additionalMapping, nameof(additionalMapping));
 
-            foreach (var level1 in other.Mapping)
+            foreach (var level1 in additionalMapping.Mapping)
             {
                 if (!Mapping.TryGetValue(level1.Key, out var level2Dict))
                 {

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/Models/CodeMapping.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/Models/CodeMapping.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 using DotLiquid;
 
@@ -16,5 +17,53 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.Models
         }
 
         public Dictionary<string, Dictionary<string, Dictionary<string, string>>> Mapping { get; set; }
+
+        /// <summary>
+        /// Appends mappings from another CodeMapping instance.
+        /// Throws InvalidOperationException if any key path already exists with a different value.
+        /// </summary>
+        /// <param name="other">The other CodeMapping to append.</param>
+        public void Append(CodeMapping other)
+        {
+            if (other == null)
+            {
+                throw new ArgumentNullException(nameof(other));
+            }
+
+            foreach (var level1 in other.Mapping)
+            {
+                if (!Mapping.TryGetValue(level1.Key, out var level2Dict))
+                {
+                    Mapping[level1.Key] = new Dictionary<string, Dictionary<string, string>>(level1.Value);
+                    continue;
+                }
+
+                foreach (var level2 in level1.Value)
+                {
+                    if (!level2Dict.TryGetValue(level2.Key, out var level3Dict))
+                    {
+                        level2Dict[level2.Key] = new Dictionary<string, string>(level2.Value);
+                        continue;
+                    }
+
+                    foreach (var level3 in level2.Value)
+                    {
+                        if (level3Dict.TryGetValue(level3.Key, out var existingValue))
+                        {
+                            if (!string.Equals(existingValue, level3.Value, StringComparison.Ordinal))
+                            {
+                                throw new InvalidOperationException(
+                                    $"Conflict at path [{level1.Key}][{level2.Key}][{level3.Key}]: " +
+                                    $"existing='{existingValue}', new='{level3.Value}'");
+                            }
+                        }
+                        else
+                        {
+                            level3Dict[level3.Key] = level3.Value;
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/Processors/CcdaProcessor.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/Processors/CcdaProcessor.cs
@@ -36,25 +36,5 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.Processors
 
             return InternalConvertFromObject(ccdaData, rootTemplate, templateProvider, traceInfo);
         }
-
-        protected override Context CreateContext(ITemplateProvider templateProvider, IDictionary<string, object> data, string rootTemplate)
-        {
-            // Load value set mapping
-            var context = base.CreateContext(templateProvider, data, rootTemplate);
-            var codeMapping = templateProvider.GetTemplate(GetCodeMappingTemplatePath(context));
-            if (codeMapping?.Root?.NodeList?.First() != null)
-            {
-                context["CodeMapping"] = codeMapping.Root.NodeList.First();
-            }
-
-            return context;
-        }
-
-        private string GetCodeMappingTemplatePath(Context context)
-        {
-            var rootTemplateParentPath = context[TemplateUtility.RootTemplateParentPathScope]?.ToString();
-            var codeSystemTemplateName = "ValueSet/ValueSet";
-            return TemplateUtility.GetFormattedTemplatePath(codeSystemTemplateName, rootTemplateParentPath);
-        }
     }
 }

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/Processors/FhirToHl7v2Processor.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/Processors/FhirToHl7v2Processor.cs
@@ -225,11 +225,11 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.Processors
             return sb.ToString();
         }
 
-        protected override Context CreateContext(ITemplateProvider templateProvider, IDictionary<string, object> data, string rootTemplate)
+        protected override Context CreateBaseContext(ITemplateProvider templateProvider, IDictionary<string, object> data)
         {
             // Load data and templates
             var cancellationToken = Settings.TimeOut > 0 ? new CancellationTokenSource(Settings.TimeOut).Token : CancellationToken.None;
-            var context = new JSchemaContext(
+            return new JSchemaContext(
                 environments: new List<Hash> { Hash.FromDictionary(data) },
                 outerScope: new Hash(),
                 registers: Hash.FromDictionary(new Dictionary<string, object> { { "file_system", templateProvider.GetTemplateFileSystem() } }),
@@ -240,11 +240,6 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.Processors
             {
                 ValidateSchemas = new List<JsonSchema>(),
             };
-
-            // Load filters
-            context.AddFilters(typeof(Filters));
-
-            return context;
         }
 
         protected override void CreateTraceInfo(object data, Context context, TraceInfo traceInfo)

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/Processors/Hl7v2Processor.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/Processors/Hl7v2Processor.cs
@@ -40,32 +40,12 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.Processors
             return InternalConvertFromObject(hl7v2Data, rootTemplate, templateProvider, traceInfo);
         }
 
-        protected override Context CreateContext(ITemplateProvider templateProvider, IDictionary<string, object> data, string rootTemplate)
-        {
-            // Load code system mapping
-            var context = base.CreateContext(templateProvider, data, rootTemplate);
-            var codeMapping = templateProvider.GetTemplate(GetCodeMappingTemplatePath(context));
-            if (codeMapping?.Root?.NodeList?.First() != null)
-            {
-                context["CodeMapping"] = codeMapping.Root.NodeList.First();
-            }
-
-            return context;
-        }
-
         protected override void CreateTraceInfo(object data, Context context, TraceInfo traceInfo)
         {
             if (traceInfo is Hl7v2TraceInfo hl7v2TraceInfo)
             {
                 hl7v2TraceInfo.UnusedSegments = Hl7v2TraceInfo.CreateTraceInfo(data as Hl7v2Data).UnusedSegments;
             }
-        }
-
-        private string GetCodeMappingTemplatePath(Context context)
-        {
-            var rootTemplateParentPath = context[TemplateUtility.RootTemplateParentPathScope]?.ToString();
-            var codeSystemTemplateName = "CodeSystem/CodeSystem";
-            return TemplateUtility.GetFormattedTemplatePath(codeSystemTemplateName, rootTemplateParentPath);
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/Processors/JsonProcessor.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/Processors/JsonProcessor.cs
@@ -54,11 +54,11 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.Processors
             return InternalConvertFromObject(jsonData, rootTemplate, templateProvider, traceInfo);
         }
 
-        protected override Context CreateContext(ITemplateProvider templateProvider, IDictionary<string, object> data, string rootTemplate)
+        protected override Context CreateBaseContext(ITemplateProvider templateProvider, IDictionary<string, object> data)
         {
             // Load data and templates
             var cancellationToken = Settings.TimeOut > 0 ? new CancellationTokenSource(Settings.TimeOut).Token : CancellationToken.None;
-            var context = new JSchemaContext(
+            return new JSchemaContext(
                 environments: new List<Hash> { Hash.FromDictionary(data) },
                 outerScope: new Hash(),
                 registers: Hash.FromDictionary(new Dictionary<string, object> { { "file_system", templateProvider.GetTemplateFileSystem() } }),
@@ -69,14 +69,6 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.Processors
             {
                 ValidateSchemas = new List<JsonSchema>(),
             };
-
-            // Load filters
-            context.AddFilters(typeof(Filters));
-
-            // Add root template's parent path to context.
-            AddRootTemplatePathScope(context, templateProvider, rootTemplate);
-
-            return context;
         }
 
         protected override void CreateTraceInfo(object data, Context context, TraceInfo traceInfo)


### PR DESCRIPTION
This PR enhances the Filter.GetProperty method across all processors to ensure that both code mappings **CodeSystem/CodeSystem** and **ValueSet/ValueSet** are read by default.

**Changes**

* Context Initialization
Adjusted context setup so that both default mappings are automatically loaded into the environment, ensuring they are available during property access.
* Adds support for combining multiple CodeMapping instances by introducing the CodeMapping.Append() method.
* Splits CreateContext(...) into CreateBaseContext(...) and CreateContext(...) for improved separation of context initialization logic.

**Impact**

This change improves consistency and reliability when processing filters across different processors by guaranteeing that both default mappings are always considered. There are no breaking changes expected for consumers relying on the current behavior, as the default mappings remain unchanged.